### PR TITLE
fix: Remove authentication dialogs in Titlepack

### DIFF
--- a/Scripts/Libs/ahmad3/GreetPlayer.Script.txt
+++ b/Scripts/Libs/ahmad3/GreetPlayer.Script.txt
@@ -334,6 +334,8 @@ Boolean Private_LoopUpdateTokenReq() {
     } else {
         G_TokenUpdateReqOk = False;
         ErrorReport::ReportPost(G_TokenUpdateReq.Route, G_TokenUpdateReq.Body, LocalUser.Login, Req.StatusCode, Req.Result);
+        // Reset to a dummy auth token, to avoid keeping it empty if it's a new player.
+        AuthUtils::SetUserToken("FAILED", LocalUser);
     }
 
     Http.Destroy(Req);
@@ -517,13 +519,7 @@ Void Private_LoopBanDialog() {
  * If they're new, the welcome dialog is initialized. Otherwise, the player update procedure begins.
  */
 Void Private_InitGreetPlayer() {
-    declare Text Token = AuthUtils::GetUserToken(LocalUser);
-
-    if (Token == "") {
-        Private_InitWelcomeDialog();
-    } else {
-        Private_InitPlayerUpdateReq();
-    }
+    Private_InitPlayerUpdateReq();
 }
 
 /**


### PR DESCRIPTION
Set the user token to non-empty when the authentication fails. This way, the Titlepack won't detect the player as new again, which would show them the welcome dialog again. This is done in conjunction with the API always returning a non-empty token when the authentication is disabled.

Closes #26.